### PR TITLE
feat(GSGGR-514): use the latest LTS ubuntu as a builder

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -236,6 +236,7 @@ services:
       - ENCRYPTION_SALT=12345678901234567890123456789012
       - EXTERNAL_URL=https://extract
       - GEODATA_POSTGRES_HOST=extract-db
+      - EXTRACT_I18N_LANGUAGE=de
     volumes:
       - ./volumes/cert:/cert
       - ./volumes/cert/:/usr/local/share/ca-certificates/

--- a/extract/Dockerfile
+++ b/extract/Dockerfile
@@ -1,5 +1,5 @@
 # Extract builder
-FROM ubuntu:oracular AS builder
+FROM ubuntu:noble AS builder
 LABEL Maintainer="andrey.rusakov@camptocamp.com" Vendor="Camptocamp"
 
 WORKDIR /extract-build


### PR DESCRIPTION
Extract uses an old ubuntu version as a builder image and that causes multiple failures, like https://github.com/camptocamp/geoshop/actions/runs/17735003023/job/50400771455.

Updated version to the most recent LTS (according to https://www.releases.ubuntu.com/)